### PR TITLE
Remove unused metrics (netuitive.aws.ebs.busytimebytespersecond, netuitive.aws.ebs.writebytespersec, netuitive.aws.ebs.readbytespersec)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 ## Release History
 
 ### Version next
+* Remove unused metrics: netuitive.aws.ebs.busytimebytespersecond, netuitive.aws.ebs.writebytespersec                         
 
 ### Version 1.7.0
 

--- a/analyticConfigurations/ace-aws.ebs.json
+++ b/analyticConfigurations/ace-aws.ebs.json
@@ -37,21 +37,7 @@
         }
       },
       {
-        "match": "netuitive.aws.ebs.busypercent",
-        "properties": {
-          "baseline": true,
-          "correlation": true
-        }
-      },
-      {
         "match": "netuitive.aws.ebs.iopsutilization",
-        "properties": {
-          "baseline": true,
-          "correlation": true
-        }
-      },
-      {
-        "match": "netuitive.aws.ebs.totalbytespersec",
         "properties": {
           "baseline": true,
           "correlation": true

--- a/analyticConfigurations/computed_metric-aws.ebs.json
+++ b/analyticConfigurations/computed_metric-aws.ebs.json
@@ -23,16 +23,6 @@
         }
       },
       {
-        "match": "netuitive.aws.ebs.readbytespersec",
-        "properties": {
-          "expressions": [
-            "${aws.ebs.volumereadbytes}.actual / 300.0"
-          ],
-          "fqn": "netuitive.aws.ebs.readbytespersec",
-          "name": "Read Bytes Per Second"
-        }
-      },
-      {
         "match": "netuitive.aws.ebs.averagereadlatency",
         "properties": {
           "expressions": [
@@ -115,7 +105,7 @@
         "match": "netuitive.aws.ebs.totalbytespersec",
         "properties": {
           "expressions": [
-            "${netuitive.aws.ebs.readbytespersec}.actual + ${aws.ebs.volumewritebytes}.actual / 300.0"
+            "(${aws.ebs.volumereadbytes}.actual + ${aws.ebs.volumewritebytes}.actual) / 300.0"
           ],
           "fqn": "netuitive.aws.ebs.totalbytespersec",
           "name": "Total Bytes Per Second"

--- a/analyticConfigurations/computed_metric-aws.ebs.json
+++ b/analyticConfigurations/computed_metric-aws.ebs.json
@@ -33,16 +33,6 @@
         }
       },
       {
-        "match": "netuitive.aws.ebs.writebytespersec",
-        "properties": {
-          "expressions": [
-            "${aws.ebs.volumewritebytes}.actual / 300.0"
-          ],
-          "fqn": "netuitive.aws.ebs.writebytespersec",
-          "name": "Write Bytes Per Second"
-        }
-      },
-      {
         "match": "netuitive.aws.ebs.averagereadlatency",
         "properties": {
           "expressions": [
@@ -125,7 +115,7 @@
         "match": "netuitive.aws.ebs.totalbytespersec",
         "properties": {
           "expressions": [
-            "${netuitive.aws.ebs.readbytespersec}.actual + ${netuitive.aws.ebs.writebytespersec}.actual"
+            "${netuitive.aws.ebs.readbytespersec}.actual + ${aws.ebs.volumewritebytes}.actual / 300.0"
           ],
           "fqn": "netuitive.aws.ebs.totalbytespersec",
           "name": "Total Bytes Per Second"
@@ -139,14 +129,6 @@
           ],
           "fqn": "netuitive.aws.ebs.totalbytes",
           "name": "Total Bytes"
-        }
-      },
-      {
-        "match": "netuitive.aws.ebs.busytimebytespersecond",
-        "properties": {
-          "expression": "(data['aws.ebs.volumeidletime'].actual >= 300) ? 0 : data['netuitive.aws.ebs.totalbytes'].actual / (300.0 - Math.floor(data['aws.ebs.volumeidletime'].actual))",
-          "fqn": "netuitive.aws.ebs.busytimebytespersecond",
-          "name": "Busy Time Bytes Per Second"
         }
       },
       {

--- a/analyticConfigurations/computed_metric-aws.ebs.json
+++ b/analyticConfigurations/computed_metric-aws.ebs.json
@@ -23,28 +23,6 @@
         }
       },
       {
-        "match": "netuitive.aws.ebs.averagereadlatency",
-        "properties": {
-          "expressions": [
-            "${aws.ebs.volumetotalreadtime}.actual / ${aws.ebs.volumereadops}.actual",
-            "0"
-          ],
-          "fqn": "netuitive.aws.ebs.averagereadlatency",
-          "name": "Average Read Latency"
-        }
-      },
-      {
-        "match": "netuitive.aws.ebs.averagewritelatency",
-        "properties": {
-          "expressions": [
-            "${aws.ebs.volumetotalwritetime}.actual / ${aws.ebs.volumewriteops}.actual",
-            "0"
-          ],
-          "fqn": "netuitive.aws.ebs.averagewritelatency",
-          "name": "Average Write Latency"
-        }
-      },
-      {
         "match": "netuitive.aws.ebs.iops",
         "properties": {
           "expressions": [
@@ -52,17 +30,6 @@
           ],
           "fqn": "netuitive.aws.ebs.iops",
           "name": "IOPS"
-        }
-      },
-      {
-        "match": "netuitive.aws.ebs.busypercent",
-        "properties": {
-          "expressions": [
-            "100 - ((${aws.ebs.volumeidletime}.actual / 300) * 100)",
-            "0"
-          ],
-          "fqn": "netuitive.aws.ebs.busypercent",
-          "name": "Busy Percent"
         }
       },
       {
@@ -79,26 +46,6 @@
           "expression": "Math.min(100, (!attribute['iops'].value ? (data['netuitive.aws.ebs.iops'].actual / 300) : (data['netuitive.aws.ebs.iops'].actual / attribute['iops'].value))*100)",
           "fqn": "netuitive.aws.ebs.iopsutilization",
           "name": "IOPS Utilization"
-        }
-      },
-      {
-        "match": "netuitive.aws.ebs.totalbytespersec",
-        "properties": {
-          "expressions": [
-            "(${aws.ebs.volumereadbytes}.actual + ${aws.ebs.volumewritebytes}.actual) / 300.0"
-          ],
-          "fqn": "netuitive.aws.ebs.totalbytespersec",
-          "name": "Total Bytes Per Second"
-        }
-      },
-      {
-        "match": "netuitive.aws.ebs.totalbytes",
-        "properties": {
-          "expressions": [
-            "${aws.ebs.volumewritebytes}.actual + ${aws.ebs.volumereadbytes}.actual"
-          ],
-          "fqn": "netuitive.aws.ebs.totalbytes",
-          "name": "Total Bytes"
         }
       },
       {

--- a/analyticConfigurations/computed_metric-aws.ebs.json
+++ b/analyticConfigurations/computed_metric-aws.ebs.json
@@ -45,26 +45,6 @@
         }
       },
       {
-        "match": "netuitive.aws.ebs.readopspersec",
-        "properties": {
-          "expressions": [
-            "${aws.ebs.volumereadops}.actual / 300.0"
-          ],
-          "fqn": "netuitive.aws.ebs.readopspersec",
-          "name": "Read Ops Per Second"
-        }
-      },
-      {
-        "match": "netuitive.aws.ebs.writeopspersec",
-        "properties": {
-          "expressions": [
-            "${aws.ebs.volumewriteops}.actual / 300.0"
-          ],
-          "fqn": "netuitive.aws.ebs.writeopspersec",
-          "name": "Write Ops Per Second"
-        }
-      },
-      {
         "match": "netuitive.aws.ebs.iops",
         "properties": {
           "expressions": [

--- a/analyticConfigurations/computed_metric-aws.ebs.json
+++ b/analyticConfigurations/computed_metric-aws.ebs.json
@@ -2,20 +2,10 @@
   "analyticConfiguration": {
     "metrics": [
       {
-        "match": "netuitive.aws.ebs.totalops",
-        "properties": {
-          "expressions": [
-            "${aws.ebs.volumereadops}.actual + ${aws.ebs.volumewriteops}.actual"
-          ],
-          "fqn": "netuitive.aws.ebs.totalops",
-          "name": "Total Ops"
-        }
-      },
-      {
         "match": "netuitive.aws.ebs.averagelatency",
         "properties": {
           "expressions": [
-            "(${aws.ebs.volumetotalreadtime}.actual + ${aws.ebs.volumetotalwritetime}.actual) / ${netuitive.aws.ebs.totalops}.actual",
+            "(${aws.ebs.volumetotalreadtime}.actual + ${aws.ebs.volumetotalwritetime}.actual) / (${aws.ebs.volumereadops}.actual + ${aws.ebs.volumewriteops}.actual)",
             "0"
           ],
           "fqn": "netuitive.aws.ebs.averagelatency",
@@ -26,7 +16,7 @@
         "match": "netuitive.aws.ebs.iops",
         "properties": {
           "expressions": [
-            "${netuitive.aws.ebs.totalops}.actual / 300.0"
+            "(${aws.ebs.volumereadops}.actual + ${aws.ebs.volumewriteops}.actual) / 300.0"
           ],
           "fqn": "netuitive.aws.ebs.iops",
           "name": "IOPS"
@@ -51,7 +41,7 @@
       {
         "match": "netuitive.aws.ebs.busytimeiops",
         "properties": {
-          "expression": "(data['aws.ebs.volumeidletime'].actual >= 300) ? 0 : data['netuitive.aws.ebs.totalops'].actual / (300.0 - Math.floor(data['aws.ebs.volumeidletime'].actual))",
+          "expression": "(data['aws.ebs.volumeidletime'].actual >= 300) ? 0 : (data['aws.ebs.volumereadops'].actual + data['aws.ebs.volumewriteops'].actual) / (300.0 - Math.floor(data['aws.ebs.volumeidletime'].actual))",
           "fqn": "netuitive.aws.ebs.busytimeiops",
           "name": "Busy Time IOPS"
         }

--- a/analyticConfigurations/metric_meta-aws.ebs.json
+++ b/analyticConfigurations/metric_meta-aws.ebs.json
@@ -134,22 +134,6 @@
             "unit": "iops"
           }
         }
-      },
-      {
-        "match": "netuitive.aws.ebs.readopspersec",
-        "properties": {
-          "tags": {
-            "unit": "rps"
-          }
-        }
-      },
-      {
-        "match": "netuitive.aws.ebs.writeopspersec",
-        "properties": {
-          "tags": {
-            "unit": "wps"
-          }
-        }
       }
     ],
     "name": "AWS EBS",

--- a/analyticConfigurations/metric_meta-aws.ebs.json
+++ b/analyticConfigurations/metric_meta-aws.ebs.json
@@ -150,14 +150,6 @@
             "unit": "wps"
           }
         }
-      },
-      {
-        "match": "netuitive.aws.ebs.busytimebytespersecond",
-        "properties": {
-          "tags": {
-            "unit": "Bps"
-          }
-        }
       }
     ],
     "name": "AWS EBS",

--- a/analyticConfigurations/metric_meta-aws.ebs.json
+++ b/analyticConfigurations/metric_meta-aws.ebs.json
@@ -29,15 +29,6 @@
         }
       },
       {
-        "match": "netuitive.aws.ebs.busypercent",
-        "properties": {
-          "tags": {
-            "unit": "percent",
-            "utilization": true
-          }
-        }
-      },
-      {
         "match": "netuitive.aws.ebs.iopsutilization",
         "properties": {
           "tags": {
@@ -93,14 +84,6 @@
         "match": "netuitive.aws.ebs.queuelengthdifferential",
         "properties": {
           "validMin": "null"
-        }
-      },
-      {
-        "match": "netuitive.aws.ebs.totalbytes",
-        "properties": {
-          "tags": {
-            "unit": "bytes"
-          }
         }
       },
       {

--- a/dashboards/aws.ebs.element.detail.json
+++ b/dashboards/aws.ebs.element.detail.json
@@ -124,23 +124,6 @@
         "widgetType": "metric-time-series"
       },
       {
-        "id": "b10784ea-2f4a-4d58-a8ee-a66d3c87124d",
-        "name": "Reads and Writes Per Second",
-        "properties": {
-          "elementScopeTypes": "[\"EBS\"]",
-          "metricLimit": "10",
-          "metrics": "[{\"fqn\":\"netuitive.aws.ebs.writeopspersec\",\"aggFns\":[]},{\"fqn\":\"netuitive.aws.ebs.readopspersec\",\"aggFns\":[]}]",
-          "selectedTab": "table",
-          "showElementTotal": "true",
-          "showHighest": "true",
-          "useAllElementScopeTags": "false",
-          "useAllMetricScopeTags": "false",
-          "useElementNameContains": "true",
-          "width": "auto"
-        },
-        "widgetType": "stacked-area"
-      },
-      {
         "id": "7d26a7fa-880b-4cec-899e-194bf1810b82",
         "name": "Tags",
         "properties": {

--- a/dashboards/aws.ebs.element.detail.json
+++ b/dashboards/aws.ebs.element.detail.json
@@ -110,20 +110,6 @@
         "widgetType": "metric-time-series"
       },
       {
-        "id": "dbb82c0b-590c-4eb3-ace4-fbb64bd98487",
-        "name": "Busy Percent",
-        "properties": {
-          "metricLimit": "10",
-          "metric_fqn": "netuitive.aws.ebs.busypercent",
-          "selectedTab": "table",
-          "showElementTotal": "true",
-          "showHighest": "true",
-          "useElementNameContains": "true",
-          "width": "medium"
-        },
-        "widgetType": "metric-time-series"
-      },
-      {
         "id": "7d26a7fa-880b-4cec-899e-194bf1810b82",
         "name": "Tags",
         "properties": {

--- a/dashboards/aws.ebs.summary.json
+++ b/dashboards/aws.ebs.summary.json
@@ -11,37 +11,6 @@
     "type": "DEFAULT",
     "widgets": [
       {
-        "id": "3e21517d-e8d9-4363-a04d-a907394f4c36",
-        "name": "Top 5 Total Bytes per Second",
-        "properties": {
-          "elementScopeTypes": "[\"EBS\"]",
-          "metricLimit": "5",
-          "metric_fqn": "netuitive.aws.ebs.totalbytespersec",
-          "selectedTab": "graph",
-          "showElementTotal": "true",
-          "showHighest": "true",
-          "useElementNameContains": "true",
-          "width": "auto"
-        },
-        "widgetType": "high-low-metric"
-      },
-      {
-        "id": "b8a2cad0-cfdd-4b95-bc11-6d5dacac48a8",
-        "name": "EBS Data",
-        "properties": {
-          "elementScopeTypes": "[\"EBS\"]",
-          "metricLimit": "10",
-          "metrics": "[{\"fqn\":\"netuitive.aws.ebs.totalops\",\"aggFn\":\"sum\"},{\"fqn\":\"netuitive.aws.ebs.totalbytespersec\",\"aggFn\":\"sum\"}]",
-          "selectedAttributes": "[{\"name\":\"availabilityZone\"},{\"name\":\"region\"},{\"name\":\"size\"}]",
-          "selectedTab": "table",
-          "showElementTotal": "true",
-          "showHighest": "true",
-          "useElementNameContains": "true",
-          "width": "auto"
-        },
-        "widgetType": "multi-metric-table"
-      },
-      {
         "id": "ad83d44e-5910-4e47-b803-d3f543c76668",
         "name": "Top 5 IOPS Utilization",
         "properties": {
@@ -58,51 +27,6 @@
           "visualization": "bar"
         },
         "widgetType": "metric-range"
-      },
-      {
-        "id": "475ac827-d1b6-4c27-8097-048c95ebe63e",
-        "name": "Top 10 Total IOPS",
-        "properties": {
-          "elementScopeTypes": "[\"EBS\"]",
-          "metricLimit": "10",
-          "metric_fqn": "netuitive.aws.ebs.totalops",
-          "selectedTab": "table",
-          "showElementTotal": "true",
-          "showHighest": "true",
-          "useElementNameContains": "true",
-          "width": "auto"
-        },
-        "widgetType": "high-low-metric"
-      },
-      {
-        "id": "ed74323e-3ea4-473c-8edf-d911cadd154a",
-        "name": "Top 10 Average Read Latency",
-        "properties": {
-          "elementScopeTypes": "[\"EBS\"]",
-          "metricLimit": "10",
-          "metric_fqn": "netuitive.aws.ebs.averagereadlatency",
-          "selectedTab": "graph",
-          "showElementTotal": "true",
-          "showHighest": "true",
-          "useElementNameContains": "true",
-          "width": "auto"
-        },
-        "widgetType": "high-low-metric"
-      },
-      {
-        "id": "a5279ef8-b608-4d31-a421-c9b459a529fe",
-        "name": "Top 10 Average Write Latency",
-        "properties": {
-          "elementScopeTypes": "[\"EBS\"]",
-          "metricLimit": "10",
-          "metric_fqn": "netuitive.aws.ebs.averagewritelatency",
-          "selectedTab": "table",
-          "showElementTotal": "true",
-          "showHighest": "true",
-          "useElementNameContains": "true",
-          "width": "auto"
-        },
-        "widgetType": "high-low-metric"
       }
     ]
   }


### PR DESCRIPTION
These metrics are not used nor in policies neither in dashboards, so removing them:
1) netuitive.aws.ebs.busytimebytespersecond
2) netuitive.aws.ebs.writebytespersec
3) netuitive.aws.ebs.readbytespersec