### PR TITLE
Remove unused metrics and adjust dashboards

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 ## Release History
 
 ### Version next
+* Remove unused metrics: netuitive.aws.ebs.busytimebytespersecond, netuitive.aws.ebs.writebytespersec                         
 
 ### Version 1.7.0
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,18 @@
 ## Release History
 
 ### Version next
-* Remove unused metrics: netuitive.aws.ebs.busytimebytespersecond, netuitive.aws.ebs.writebytespersec                         
+* Remove metrics: netuitive.aws.ebs.busytimebytespersecond
+                  netuitive.aws.ebs.writebytespersec
+                  netuitive.aws.ebs.readbytespersec
+                  netuitive.aws.ebs.busypercent
+                  netuitive.aws.ebs.writeopspersec
+                  netuitive.aws.ebs.readopspersec
+                  netuitive.aws.ebs.totalbytespersec
+                  netuitive.aws.ebs.totalops
+                  netuitive.aws.ebs.averagereadlatency
+                  netuitive.aws.ebs.averagewritelatency
+                  netuitive.aws.ebs.totalbytes
+* Replace deleted metrics with other ones in dashboards AWS EBS Summary AWS EBS Element Detail                          
 
 ### Version 1.7.0
 

--- a/analyticConfigurations/ace-aws.ebs.json
+++ b/analyticConfigurations/ace-aws.ebs.json
@@ -37,21 +37,7 @@
         }
       },
       {
-        "match": "netuitive.aws.ebs.busypercent",
-        "properties": {
-          "baseline": true,
-          "correlation": true
-        }
-      },
-      {
         "match": "netuitive.aws.ebs.iopsutilization",
-        "properties": {
-          "baseline": true,
-          "correlation": true
-        }
-      },
-      {
-        "match": "netuitive.aws.ebs.totalbytespersec",
         "properties": {
           "baseline": true,
           "correlation": true

--- a/analyticConfigurations/computed_metric-aws.ebs.json
+++ b/analyticConfigurations/computed_metric-aws.ebs.json
@@ -23,16 +23,6 @@
         }
       },
       {
-        "match": "netuitive.aws.ebs.readbytespersec",
-        "properties": {
-          "expressions": [
-            "${aws.ebs.volumereadbytes}.actual / 300.0"
-          ],
-          "fqn": "netuitive.aws.ebs.readbytespersec",
-          "name": "Read Bytes Per Second"
-        }
-      },
-      {
         "match": "netuitive.aws.ebs.averagereadlatency",
         "properties": {
           "expressions": [
@@ -115,7 +105,7 @@
         "match": "netuitive.aws.ebs.totalbytespersec",
         "properties": {
           "expressions": [
-            "${netuitive.aws.ebs.readbytespersec}.actual + ${aws.ebs.volumewritebytes}.actual / 300.0"
+            "(${aws.ebs.volumereadbytes}.actual + ${aws.ebs.volumewritebytes}.actual) / 300.0"
           ],
           "fqn": "netuitive.aws.ebs.totalbytespersec",
           "name": "Total Bytes Per Second"

--- a/analyticConfigurations/computed_metric-aws.ebs.json
+++ b/analyticConfigurations/computed_metric-aws.ebs.json
@@ -33,16 +33,6 @@
         }
       },
       {
-        "match": "netuitive.aws.ebs.writebytespersec",
-        "properties": {
-          "expressions": [
-            "${aws.ebs.volumewritebytes}.actual / 300.0"
-          ],
-          "fqn": "netuitive.aws.ebs.writebytespersec",
-          "name": "Write Bytes Per Second"
-        }
-      },
-      {
         "match": "netuitive.aws.ebs.averagereadlatency",
         "properties": {
           "expressions": [
@@ -125,7 +115,7 @@
         "match": "netuitive.aws.ebs.totalbytespersec",
         "properties": {
           "expressions": [
-            "${netuitive.aws.ebs.readbytespersec}.actual + ${netuitive.aws.ebs.writebytespersec}.actual"
+            "${netuitive.aws.ebs.readbytespersec}.actual + ${aws.ebs.volumewritebytes}.actual / 300.0"
           ],
           "fqn": "netuitive.aws.ebs.totalbytespersec",
           "name": "Total Bytes Per Second"
@@ -139,14 +129,6 @@
           ],
           "fqn": "netuitive.aws.ebs.totalbytes",
           "name": "Total Bytes"
-        }
-      },
-      {
-        "match": "netuitive.aws.ebs.busytimebytespersecond",
-        "properties": {
-          "expression": "(data['aws.ebs.volumeidletime'].actual >= 300) ? 0 : data['netuitive.aws.ebs.totalbytes'].actual / (300.0 - Math.floor(data['aws.ebs.volumeidletime'].actual))",
-          "fqn": "netuitive.aws.ebs.busytimebytespersecond",
-          "name": "Busy Time Bytes Per Second"
         }
       },
       {

--- a/analyticConfigurations/computed_metric-aws.ebs.json
+++ b/analyticConfigurations/computed_metric-aws.ebs.json
@@ -2,20 +2,10 @@
   "analyticConfiguration": {
     "metrics": [
       {
-        "match": "netuitive.aws.ebs.totalops",
-        "properties": {
-          "expressions": [
-            "${aws.ebs.volumereadops}.actual + ${aws.ebs.volumewriteops}.actual"
-          ],
-          "fqn": "netuitive.aws.ebs.totalops",
-          "name": "Total Ops"
-        }
-      },
-      {
         "match": "netuitive.aws.ebs.averagelatency",
         "properties": {
           "expressions": [
-            "(${aws.ebs.volumetotalreadtime}.actual + ${aws.ebs.volumetotalwritetime}.actual) / ${netuitive.aws.ebs.totalops}.actual",
+            "(${aws.ebs.volumetotalreadtime}.actual + ${aws.ebs.volumetotalwritetime}.actual) / (${aws.ebs.volumereadops}.actual + ${aws.ebs.volumewriteops}.actual)",
             "0"
           ],
           "fqn": "netuitive.aws.ebs.averagelatency",
@@ -23,66 +13,13 @@
         }
       },
       {
-        "match": "netuitive.aws.ebs.averagereadlatency",
-        "properties": {
-          "expressions": [
-            "${aws.ebs.volumetotalreadtime}.actual / ${aws.ebs.volumereadops}.actual",
-            "0"
-          ],
-          "fqn": "netuitive.aws.ebs.averagereadlatency",
-          "name": "Average Read Latency"
-        }
-      },
-      {
-        "match": "netuitive.aws.ebs.averagewritelatency",
-        "properties": {
-          "expressions": [
-            "${aws.ebs.volumetotalwritetime}.actual / ${aws.ebs.volumewriteops}.actual",
-            "0"
-          ],
-          "fqn": "netuitive.aws.ebs.averagewritelatency",
-          "name": "Average Write Latency"
-        }
-      },
-      {
-        "match": "netuitive.aws.ebs.readopspersec",
-        "properties": {
-          "expressions": [
-            "${aws.ebs.volumereadops}.actual / 300.0"
-          ],
-          "fqn": "netuitive.aws.ebs.readopspersec",
-          "name": "Read Ops Per Second"
-        }
-      },
-      {
-        "match": "netuitive.aws.ebs.writeopspersec",
-        "properties": {
-          "expressions": [
-            "${aws.ebs.volumewriteops}.actual / 300.0"
-          ],
-          "fqn": "netuitive.aws.ebs.writeopspersec",
-          "name": "Write Ops Per Second"
-        }
-      },
-      {
         "match": "netuitive.aws.ebs.iops",
         "properties": {
           "expressions": [
-            "${netuitive.aws.ebs.totalops}.actual / 300.0"
+            "(${aws.ebs.volumereadops}.actual + ${aws.ebs.volumewriteops}.actual) / 300.0"
           ],
           "fqn": "netuitive.aws.ebs.iops",
           "name": "IOPS"
-        }
-      },
-      {
-        "match": "netuitive.aws.ebs.busypercent",
-        "properties": {
-          "expressions": [
-            "100 - ((${aws.ebs.volumeidletime}.actual / 300) * 100)",
-            "0"
-          ],
-          "fqn": "netuitive.aws.ebs.busypercent",
-          "name": "Busy Percent"
         }
       },
       {
@@ -102,29 +39,9 @@
         }
       },
       {
-        "match": "netuitive.aws.ebs.totalbytespersec",
-        "properties": {
-          "expressions": [
-            "(${aws.ebs.volumereadbytes}.actual + ${aws.ebs.volumewritebytes}.actual) / 300.0"
-          ],
-          "fqn": "netuitive.aws.ebs.totalbytespersec",
-          "name": "Total Bytes Per Second"
-        }
-      },
-      {
-        "match": "netuitive.aws.ebs.totalbytes",
-        "properties": {
-          "expressions": [
-            "${aws.ebs.volumewritebytes}.actual + ${aws.ebs.volumereadbytes}.actual"
-          ],
-          "fqn": "netuitive.aws.ebs.totalbytes",
-          "name": "Total Bytes"
-        }
-      },
-      {
         "match": "netuitive.aws.ebs.busytimeiops",
         "properties": {
-          "expression": "(data['aws.ebs.volumeidletime'].actual >= 300) ? 0 : data['netuitive.aws.ebs.totalops'].actual / (300.0 - Math.floor(data['aws.ebs.volumeidletime'].actual))",
+          "expression": "(data['aws.ebs.volumeidletime'].actual >= 300) ? 0 : (data['aws.ebs.volumereadops'].actual + data['aws.ebs.volumewriteops'].actual) / (300.0 - Math.floor(data['aws.ebs.volumeidletime'].actual))",
           "fqn": "netuitive.aws.ebs.busytimeiops",
           "name": "Busy Time IOPS"
         }

--- a/analyticConfigurations/metric_meta-aws.ebs.json
+++ b/analyticConfigurations/metric_meta-aws.ebs.json
@@ -150,14 +150,6 @@
             "unit": "wps"
           }
         }
-      },
-      {
-        "match": "netuitive.aws.ebs.busytimebytespersecond",
-        "properties": {
-          "tags": {
-            "unit": "Bps"
-          }
-        }
       }
     ],
     "name": "AWS EBS",

--- a/analyticConfigurations/metric_meta-aws.ebs.json
+++ b/analyticConfigurations/metric_meta-aws.ebs.json
@@ -29,15 +29,6 @@
         }
       },
       {
-        "match": "netuitive.aws.ebs.busypercent",
-        "properties": {
-          "tags": {
-            "unit": "percent",
-            "utilization": true
-          }
-        }
-      },
-      {
         "match": "netuitive.aws.ebs.iopsutilization",
         "properties": {
           "tags": {
@@ -96,14 +87,6 @@
         }
       },
       {
-        "match": "netuitive.aws.ebs.totalbytes",
-        "properties": {
-          "tags": {
-            "unit": "bytes"
-          }
-        }
-      },
-      {
         "match": "aws.ebs.volumethroughputpercentage",
         "properties": {
           "tags": {
@@ -132,22 +115,6 @@
         "properties": {
           "tags": {
             "unit": "iops"
-          }
-        }
-      },
-      {
-        "match": "netuitive.aws.ebs.readopspersec",
-        "properties": {
-          "tags": {
-            "unit": "rps"
-          }
-        }
-      },
-      {
-        "match": "netuitive.aws.ebs.writeopspersec",
-        "properties": {
-          "tags": {
-            "unit": "wps"
           }
         }
       }

--- a/dashboards/aws.ebs.element.detail.json
+++ b/dashboards/aws.ebs.element.detail.json
@@ -129,7 +129,7 @@
         "properties": {
           "elementScopeTypes": "[\"EBS\"]",
           "metricLimit": "10",
-          "metrics": "[{\"fqn\":\"aws.ebs.volumewriteops\",\"aggFns\":[]},{\"fqn\":\"aws.ebs.volumereadops\",\"aggFns\":[]}]",
+          "metrics": "[{\"fqn\":\"aws.ebs.volumewriteops\",\"aggFn\":\"sum\"},{\"fqn\":\"aws.ebs.volumereadops\",\"aggFn\":\"sum\"}]",
           "selectedTab": "table",
           "showElementTotal": "true",
           "showHighest": "true",

--- a/dashboards/aws.ebs.element.detail.json
+++ b/dashboards/aws.ebs.element.detail.json
@@ -111,10 +111,10 @@
       },
       {
         "id": "dbb82c0b-590c-4eb3-ace4-fbb64bd98487",
-        "name": "Busy Percent",
+        "name": "Volume Queue Length",
         "properties": {
           "metricLimit": "10",
-          "metric_fqn": "netuitive.aws.ebs.busypercent",
+          "metric_fqn": "aws.ebs.volumequeuelength",
           "selectedTab": "table",
           "showElementTotal": "true",
           "showHighest": "true",
@@ -125,11 +125,11 @@
       },
       {
         "id": "b10784ea-2f4a-4d58-a8ee-a66d3c87124d",
-        "name": "Reads and Writes Per Second",
+        "name": "Read and Write Ops",
         "properties": {
           "elementScopeTypes": "[\"EBS\"]",
           "metricLimit": "10",
-          "metrics": "[{\"fqn\":\"netuitive.aws.ebs.writeopspersec\",\"aggFns\":[]},{\"fqn\":\"netuitive.aws.ebs.readopspersec\",\"aggFns\":[]}]",
+          "metrics": "[{\"fqn\":\"aws.ebs.volumewriteops\",\"aggFns\":[]},{\"fqn\":\"aws.ebs.volumereadops\",\"aggFns\":[]}]",
           "selectedTab": "table",
           "showElementTotal": "true",
           "showHighest": "true",

--- a/dashboards/aws.ebs.summary.json
+++ b/dashboards/aws.ebs.summary.json
@@ -12,11 +12,11 @@
     "widgets": [
       {
         "id": "3e21517d-e8d9-4363-a04d-a907394f4c36",
-        "name": "Top 5 Total Bytes per Second",
+        "name": "Top 5 Average Latency",
         "properties": {
           "elementScopeTypes": "[\"EBS\"]",
           "metricLimit": "5",
-          "metric_fqn": "netuitive.aws.ebs.totalbytespersec",
+          "metric_fqn": "netuitive.aws.ebs.averagelatency",
           "selectedTab": "graph",
           "showElementTotal": "true",
           "showHighest": "true",
@@ -31,7 +31,7 @@
         "properties": {
           "elementScopeTypes": "[\"EBS\"]",
           "metricLimit": "10",
-          "metrics": "[{\"fqn\":\"netuitive.aws.ebs.totalops\",\"aggFn\":\"sum\"},{\"fqn\":\"netuitive.aws.ebs.totalbytespersec\",\"aggFn\":\"sum\"}]",
+          "metrics": "[{\"fqn\":\"aws.ebs.volumequeuelength\",\"aggFn\":\"sum\"},{\"fqn\":\"netuitive.aws.ebs.queuelengthdifferential\",\"aggFn\":\"sum\"}]",
           "selectedAttributes": "[{\"name\":\"availabilityZone\"},{\"name\":\"region\"},{\"name\":\"size\"}]",
           "selectedTab": "table",
           "showElementTotal": "true",
@@ -61,12 +61,12 @@
       },
       {
         "id": "475ac827-d1b6-4c27-8097-048c95ebe63e",
-        "name": "Top 10 Total IOPS",
+        "name": "Top 10 IOPS",
         "properties": {
           "elementScopeTypes": "[\"EBS\"]",
           "metricLimit": "10",
-          "metric_fqn": "netuitive.aws.ebs.totalops",
-          "selectedTab": "table",
+          "metric_fqn": "netuitive.aws.ebs.iops",
+          "selectedTab": "graph",
           "showElementTotal": "true",
           "showHighest": "true",
           "useElementNameContains": "true",
@@ -76,11 +76,11 @@
       },
       {
         "id": "ed74323e-3ea4-473c-8edf-d911cadd154a",
-        "name": "Top 10 Average Read Latency",
+        "name": "Top 10 Volume Total Read Time",
         "properties": {
           "elementScopeTypes": "[\"EBS\"]",
           "metricLimit": "10",
-          "metric_fqn": "netuitive.aws.ebs.averagereadlatency",
+          "metric_fqn": "aws.ebs.volumetotalreadtime",
           "selectedTab": "graph",
           "showElementTotal": "true",
           "showHighest": "true",
@@ -91,12 +91,12 @@
       },
       {
         "id": "a5279ef8-b608-4d31-a421-c9b459a529fe",
-        "name": "Top 10 Average Write Latency",
+        "name": "Top 10 Volume Total Write Time",
         "properties": {
           "elementScopeTypes": "[\"EBS\"]",
           "metricLimit": "10",
-          "metric_fqn": "netuitive.aws.ebs.averagewritelatency",
-          "selectedTab": "table",
+          "metric_fqn": "aws.ebs.volumetotalwritetime",
+          "selectedTab": "graph",
           "showElementTotal": "true",
           "showHighest": "true",
           "useElementNameContains": "true",

--- a/dashboards/aws.ebs.summary.json
+++ b/dashboards/aws.ebs.summary.json
@@ -31,7 +31,7 @@
         "properties": {
           "elementScopeTypes": "[\"EBS\"]",
           "metricLimit": "10",
-          "metrics": "[{\"fqn\":\"aws.ebs.volumequeuelength\",\"aggFn\":\"sum\"},{\"fqn\":\"netuitive.aws.ebs.queuelengthdifferential\",\"aggFn\":\"sum\"}]",
+          "metrics": "[{\"fqn\":\"aws.ebs.volumequeuelength\",\"aggFn\":\"sum\"},{\"fqn\":\"netuitive.aws.ebs.queuelengthdifferential\",\"aggFn\":\"avg\"}]",
           "selectedAttributes": "[{\"name\":\"availabilityZone\"},{\"name\":\"region\"},{\"name\":\"size\"}]",
           "selectedTab": "table",
           "showElementTotal": "true",


### PR DESCRIPTION
1. Remove unused metrics: `netuitive.aws.ebs.busytimebytespersecond, netuitive.aws.ebs.writebytespersec, netuitive.aws.ebs.readbytespersec`

2. Replace metrics in dashboards: `netuitive.aws.ebs.busypercent, netuitive.aws.ebs.writeopspersec, netuitive.aws.ebs.readopspersec, netuitive.aws.ebs.totalbytespersec, netuitive.aws.ebs.totalops, netuitive.aws.ebs.averagereadlatency, netuitive.aws.ebs.averagewritelatency`

3. Inline computed metric: `netuitive.aws.ebs.totalbytes`